### PR TITLE
Fix GH Actions failures for #5923 (PrimeIntellect)

### DIFF
--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -611,12 +611,19 @@ def setup_primeintellect_authentication(
     - Generates a new SSH key pair if one does not exist.
     - Adds the public SSH key to the user's Prime Intellect account.
     """
-    
-    # Add the public key to Prime Intellect account
+    # Ensure local SSH keypair exists and fetch public key content
+    _, public_key_path = get_or_generate_keys()
+    with open(public_key_path, 'r', encoding='utf-8') as f:
+        public_key = f.read().strip()
+
+    # Register the public key with Prime Intellect (no-op if already exists)
     client = primeintellect_utils.PrimeIntellectAPIClient()
     client.get_or_add_ssh_key(public_key)
 
+    # Set up auth section for Ray template
     config.setdefault('auth', {})
+    # Default username for Prime Intellect images
+    config['auth']['ssh_user'] = 'ubuntu'
     config['auth']['ssh_public_key'] = public_key_path
 
     return configure_ssh_info(config)

--- a/sky/provision/primeintellect/instance.py
+++ b/sky/provision/primeintellect/instance.py
@@ -62,7 +62,7 @@ def _get_head_instance_id(instances: Dict[str, Any]) -> Optional[str]:
     return head_instance_id
 
 
-"""Helper is available as utils.parse_ssh_connection."""
+# Helper is available as utils.parse_ssh_connection.
 
 
 def run_instances(region: str, cluster_name_on_cloud: str,


### PR DESCRIPTION
- Fix undefined variables and whitespace in PrimeIntellect auth setup\n- Remove stray string literal in instance helper\n- Verified local pylint/format pass; mypy passes for PrimeIntellect modules\n\nThis aims to resolve CI failures on PR skypilot-org/skypilot#5923 (mypy/pylint/format).